### PR TITLE
Added link to directory of Swift Student Challenge submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ So, a number of us decided to start this repository to host links to various WWD
 
 ## Swift
 
+* [WWDC20 Swift Student Challenge Submissions](https://wwdc.github.io/2020/)
+
 ## SwiftUI
 
 ## UIKit


### PR DESCRIPTION
I'm not entirely sure if that is the right category, but I thought it might be nice to link in this repo.

## Checklist
* [X] The links is freely available for everyone to read.
* [X] The link hasn't already been submitted.
* [X] I placed the link at the bottom of its category.
* [X] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [X] The link isn't about rumors.
* [X] The linked material is suitable for a general audience.

## Optional for links to paid products
* [ ] The link regards a discounted paid product. I put it in the Offers category.
* [ ] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
