### PR TITLE
Add link to WWDC session summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ So, a number of us decided to start this repository to host links to various WWD
 * [A Guide to Maximizing the Value of WWDC](https://www.hireappdeveloper.org/blog/A-Guide-to-Maximizing-the-Value-of-WWDC.html) from John M. P. Knox
 * [WWDC20 SOTU Overview](https://swiftcompiled.com/wwdc20-whats-new-for-developers/) by Alex Brown (SwiftCompiled.com)
 * [Inferring the "D" in "WWDC"](https://mailchi.mp/6ba0b7dd3432/news-from-apples-developer-conference) from Daniel H Steinberg
+* [WWDC20 Session Summaries](https://github.com/Blackjacx/WWDC) from Stefan Herold
 
 
 ## Podcasts


### PR DESCRIPTION
Usually it is much faster to read through some bullet points instead of watching a 50 min session video. This github repo aims to offer right this!