### PR TITLE
Add WWDCTracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ So, a number of us decided to start this repository to host links to various WWD
 * [WWDC20 Swift Student Challenge Submissions](https://wwdc.github.io/2020/)
 * [A Guide to Maximizing the Value of WWDC](https://www.hireappdeveloper.org/blog/A-Guide-to-Maximizing-the-Value-of-WWDC.html) from John M. P. Knox
 * [Inferring the "D" in "WWDC"](https://mailchi.mp/6ba0b7dd3432/news-from-apples-developer-conference) from Daniel H Steinberg
+* [WWDC Tracker](https://github.com/Matthewspear/WWDCTracker) from Matthew Spear
 
 
 ## Podcasts


### PR DESCRIPTION
My link is more of a resource than blog post I hope that is ok / useful to people!
I put my resource under "Misc."

## Checklist
* [x] The links is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.