### PR TITLE
Fix typo in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Checklist
-* [ ] The links is freely available for everyone to read.
+* [ ] The link is freely available for everyone to read.
 * [ ] The link hasn't already been submitted.
 * [ ] I placed the link at the bottom of its category.
 * [ ] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ So, a number of us decided to start this repository to host links to various WWD
 ## Swift
 * [What's new in Swift 5.3](https://www.hackingwithswift.com/articles/218/whats-new-in-swift-5-3) from Hacking with Swift
 * [Swift Package Testing](https://roundwallsoftware.com/swift-package-testing/) from Samuel at Roundwall Software
+* [Gosh Darn Multiple Trailing Closure Syntax](https://goshdarnmultipletrailingclosuresyntax.com) by [Prathamesh Kowarkar](https://twitter.com/prtmshk)
 
 ## SwiftUI
 * [What’s new in SwiftUI for iOS 14](https://www.hackingwithswift.com/articles/221/whats-new-in-swiftui-for-ios-14) from Hacking with Swift


### PR DESCRIPTION
Fixed “The links is…" to “The link is…" in the first point of the checklist.