### PR TITLE
Added link to my WWDC 2020 Summary Airtable base

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ So, a number of us decided to start this repository to host links to various WWD
 * [WWDC Notes](https://wwdcnotes.com) from the WWDC community
 * [WWDC 2020 Viewing Guide](https://useyourloaf.com/blog/wwdc-2020-viewing-guide/) from [Keith Harrison](https://useyourloaf.com)
 * [WWDC20](https://engineering.monstar-lab.com/2020/06/26/WWDC20-summary) from [Heidi Puk](https://twitter.com/HeidiPuk), Tom Müller, Jigna Patel and [Christian Weinberger](https://twitter.com/_cweinberger)
+* [All WWDC 2020 Sessions in one Airtable base](https://airtable.com/shrBnfnUp4DpC6ktO/tblG1cvawBxvA6wUS) by [Gregory Berngardt](https://github.com/gregoryvit)
 
 ## Swift
 * [What's new in Swift 5.3](https://www.hackingwithswift.com/articles/218/whats-new-in-swift-5-3) from Hacking with Swift


### PR DESCRIPTION
Collected all WWDC 2020 sessions grouped by topics to Airtable base.
Hope it could be useful for someone.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.

## Optional for links to paid products
* [ ] The link regards a discounted paid product. I put it in the Offers category.
* [ ] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
