### PR TITLE
Fixes framework typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ So, a number of us decided to start this repository to host links to various WWD
 * [SwiftUI Grids](https://nsscreencast.com/episodes/445-swiftui-grids) from NSScreencast (free video)
 * [Coloring SVG assets in SwiftUI](https://ericasadun.com/2020/06/25/coloring-svg-assets-in-swiftui/) from [Erica Sadun](https://twitter.com/ericasadun)
 * [How do I Add a Global Accent Color to a SwiftUI 1.0 Project?](https://www.bigmountainstudio.com/members/posts/27630-how-do-i-add-a-global-accent-color-to-a-swiftui-1-0-project) from [Mark Moeykens](https://twitter.com/bigmtnstudio)
-* [Build interactions using SceneKit and SwiftUI](https://munirwanis.github.io/blog/2020/wwdc20-scenekit-swiftui/) from [Munir Wanis](https://twitter.com/munirwanis)
+* [Build interactions using SpriteKit and SwiftUI](https://munirwanis.github.io/blog/2020/wwdc20-spritekit-swiftui/) from [Munir Wanis](https://twitter.com/munirwanis)
 * [Building a Cash Flow App with Amplify DataStore and SwiftUI](https://aws.amazon.com/blogs/mobile/building-a-cash-flow-app-with-amplify-datastore-and-swiftui/) from [Kilo Loco](https://twitter.com/kilo_loco)
 * [A compositional wrapper around the new SwiftUI's Grid API](https://github.com/jVirus/grid-compositional-layout) from [Astemir Eleev](https://jvirus.github.io)
 * [Multiplatform template to use the new Sidebar on macOS, iOS and iPadOS](https://github.com/Volker88/UniversalSwiftUISidebar) from [Volker Schmitt](https://github.com/Volker88)


### PR DESCRIPTION
Hi, a reader mentioned a typo a few days ago. I meant to say `SpriteKit` instead of `SceneKit` on the article title. 😅 

## Checklist
* [X] The link is freely available for everyone to read.
* [X] The link hasn't already been submitted.
* [X] I placed the link at the bottom of its category.
* [X] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [X] The link isn't about rumors.
* [X] The linked material is suitable for a general audience.
