### PR TITLE
Adding notifications section and article from OneSignal

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ So, a number of us decided to start this repository to host links to various WWD
 
 * [What's New in Xcode 13](https://youtu.be/8OIyptQpzMQ) by Sean Allen
 
+## Notifications
+
+* [iOS Notification Changes & Updates from Apple’s WWDC ‘21](https://onesignal.com/blog/ios-notification-changes-updates-from-apples-wwdc-21/) by Elliot Mawby and Eva Wei 
+
 
 ## Misc
 


### PR DESCRIPTION
The article was written by myself (Elliot Mawby) and Eva Wei about the new notifications apis and features in iOS 15. It contains information for the general public as well as some developer specific information.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.

## Optional for links to paid products
* [ ] The link regards a discounted paid product. I put it in the Offers category.
* [ ] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
