### PR TITLE
Add NSLondon event at AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ There are lots of other events and watch parties taking place around the world a
 - Sunday June 4th through Friday 9th: [boulderOS WWDC 2023](https://boulderos.com/wwdc2023.html), Boulder, Colorado, USA
 - Monday June 5th through Saturday 10th: [SwiftGG-WWDC.playground](https://swift.gg/wwdc23/index_en.html)
 - Friday June 9th, [try! Swift Dub Dub](https://www.tryswift.co/dub-dub)
-- Thursday June 8th: [NSLondon 2023.2 at AWS](https://www.meetup.com/nslondon/events/293445940/)
+- Thursday June 8th: [NSLondon 2023.2 at AWS](https://www.meetup.com/nslondon/events/293445940/), London, UK
 
 
 ### Keynote watch parties


### PR DESCRIPTION
This event is not strictly about WWDC as the talks are focused on server-side Swift. We had the opportunity to put on this event and it seemed like good timing since if a lot of Swift developers get together during WWDC week they‘re going to have a lot of chat about.

I would understand if you think this event isn‘t a good fit.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [ ] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
    * Match the format of the items above it.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.
