### PR TITLE
CocoaHeadsMK WWDC keynote watch along in Skopje

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you’d like to watch Apple’s keynote with other folks, you’re in luck! T
 - June 5th, 22:30pm-4am JST: [Extended Tokyo at Yahoo Kioicho, Tokyo](https://yj-meetup.connpass.com/event/281562/)
 - June 6th, 1am SGT: [iOS Dev Scout WWDC Watch Party, online](https://www.meetup.com/singapore-ios-dev-scout-meetup/events/292400807/)
 - June 6th, 12am PHT: [SwiftPH WWDC23 Watch Party, online](bit.ly/swiftph-members-form)
-
+- June 5th, 7pm-21pm CEST: [CocoaHeadsMK: WWDC'23 Keynote Watch Along](https://cocoaheads.mk/#meetups)
 
 ## WWDC23 Deals
 


### PR DESCRIPTION
Link to the event for the WWDC 2023 Keynote in person watching session organised by _CocoaHeadsMK_ community in Skopje, Macedonia. The url links to the _CocoaHeadsMK_ website with all the meet-ups organised by the community where at the top is the _WWDC'23 Watch Along_.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.

## Optional for links to paid products
* [ ] The link regards a discounted paid product. I put it in the Offers category.
* [ ] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
