### PR TITLE
docs: Add Haptrix WWDC 2023 Week-long deal

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If you’d like to watch Apple’s keynote with other folks, you’re in luck! T
 - [Save 50% on your first year of Amato Pro with code WWDC23](https://apps.apple.com/app/id1614085893) by [Anika Seibezeder](https://twitter.com/anikaseibezeder)
 - [Save 40% on MediaMate](https://twitter.com/mediamateapp/status/1665438922464165891) by [Wouter Hennen](https://twitter.com/wouterhennen)
 - [Save 67% on Mango 5Star](https://apps.apple.com/app/mango-5star/id1473088658) by [Yilei "Dolee" Yang](https://twitter.com/DoleeYang)
+- [Save 50% on Haptrix](https://apps.apple.com/us/app/haptrix/id887185157) by [Chris Davis](https://twitter.com/nthState)
 
 ## Summaries
 


### PR DESCRIPTION
# Adding Haptrix to WWDC 2023 Deals

Hi, Haptrix the Core Haptics Experience Designer is 50% off from Monday 5th June to Friday 9th June

www.haptrix.com

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [ x The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.

## Optional for links to paid products
* [x] The link regards a discounted paid product. I put it in the Offers category.
* [x] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
