### PR TITLE
Link to recording since event has passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If you’d like to watch Apple’s keynote with other folks, you’re in luck! T
 
 ## Podcasts
 
-- [WWDC 2023 First Impressions Livecast event](https://www.kodeco.com/40370994-don-t-miss-our-wwdc-2023-livecast-june-5-9pm-edt) from Kodeco.
+- [WWDC 2023 First Impressions Livecast recording](https://www.kodeco.com/40610152-wwdc-2023-first-impressions-livecast) from Kodeco.
 - [Code Completion](https://youtube.com/live/RAxMMurpyXU) iOS Development Podcast by [Dimitri Bouniol](http://mastodon.social/@dimitribouniol) and [Spencer Curtis](https://mastodon.social/@spencercurtis), live on Keynote Monday at 4pm Pacific.
 
 ## SwiftUI


### PR DESCRIPTION
Updated the Kodeco livecast link to go to the blog post linking to the recording since this is now in the past, so folks can no longer sign up.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.

## Optional for links to paid products
* [ ] The link regards a discounted paid product. I put it in the Offers category.
* [ ] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
