### PR TITLE
Add WWDC Notes community project to worldwide events

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ MONDAY, June 10th
 
 There are lots of other events and watch parties taking place around the world and online:
 
-- Add your event here with a pull request!
+TUESDAY, June 11th
+- [WWDC Notes](https://wwdcnotes.com/) from voluntary members of our community, maybe you? (organized by Cihat Gündüz)
 
+- Add your event here with a pull request!
 
 ### Keynote watch parties
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ MONDAY, June 10th
 There are lots of other events and watch parties taking place around the world and online:
 
 TUESDAY, June 11th
-- [WWDC Notes](https://wwdcnotes.com/) from voluntary members of our community, maybe you? (organized by Cihat Gündüz)
+- [WWDC Notes](https://wwdcnotes.com/) from voluntary members of our community, maybe you? (organized by [Cihat Gündüz](https://github.com/Jeehut))
 
 - Add your event here with a pull request!
 


### PR DESCRIPTION
Last year a separate section was created for "Summaries", but it ended up only listing the WWDC Notes project. But this project really kicks off when the first sessions are out, which usually happens on the second day of WWDC, so I've just put it to June 11th where it really starts. I'm not sure though, looking forward to your thoughts.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.