### PR TITLE
Add June 8 Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ There are lots of events happening in and around Cupertino, along with other eve
 
 ### Events in and around Cupertino
 
+SATURDAY, JUNE 8th
+- 5pm-8pm: Informal meetup at San Pedro Square patio area outside of Voyager Craft Coffee.
+
 SUNDAY, June 9th
 - 9am-10am: [r/VisionPro Coffee Meetup](https://www.reddit.com/r/VisionPro/comments/1cmg3pj/wwdc24_rvisionpro_meetup/) (informal)
 - 12pm-2pm: [Core Coffee – WWDC Edition](https://www.meetup.com/core-coffee-a-catch-up-for-ios-and-macos-developers/events/300224553/)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are lots of events happening in and around Cupertino, along with other eve
 ### Events in and around Cupertino
 
 SATURDAY, JUNE 8th
-- 5pm-8pm: Informal meetup at San Pedro Square patio area outside of Voyager Craft Coffee.
+- 5pm-8pm: [Informal Pre-WWDC 24 Gathering in San Pedro Square](https://pre-wwdc24-gathering.splashthat.com) (informal)
 
 SUNDAY, June 9th
 - 9am-10am: [r/VisionPro Coffee Meetup](https://www.reddit.com/r/VisionPro/comments/1cmg3pj/wwdc24_rvisionpro_meetup/) (informal)


### PR DESCRIPTION
Add informal meetup at San Pedro Square on June 8, 2024.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.

## Optional for links to paid products
* [ ] The link regards a discounted paid product. I put it in the Offers category.
* [ ] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
