### PR TITLE
Add LIVE near WWDC event

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ TUESDAY, June 11th
 
 WEDNESDAY, June 12th
 - [One More Thing conference](https://omt-conf.com/) 10am-5pm, talks TBA (requires ticket; limited capacity)
+- [James Dempsey <sup>and</sup><sub>the</sub> Breakpoints: LIVE near WWDC](https://livenearwwdc.com) 7pm-11pm, music starts about 8, (requires ticket; limited capacity)
 
 THURSDAY, June 13th
 - [One More Thing conference](https://omt-conf.com/) 10am-5pm, talks TBA, special event by Paul Hudson (requires ticket; limited capacity)


### PR DESCRIPTION
Add link for LIVE near WWDC 2024 event.

## Checklist
* [x ] The link is freely available for everyone to read.
* [ x] The link hasn't already been submitted.
* [x ] I placed the link at the bottom of its category.
* [ x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`. (Matched other event links)
* [ x] The link isn't about rumors.
* [ x] The linked material is suitable for a general audience.

## Optional for links to paid products
* [ ] The link regards a discounted paid product. I put it in the Offers category.
* [ ] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
