### PR TITLE
Add WWDC Notes community project to worldwide events

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ FRIDAY, June 14th
 
 There are lots of other events and watch parties taking place around the world and online:
 
+MONDAY, June 10th onwards
+- [WWDC Notes](https://wwdcnotes.com/beta) from voluntary members of our community, maybe you? (organized by [Cihat Gündüz](https://github.com/Jeehut))
+
 - Add your event here with a pull request!
 
 WEDNESDAY, June 12th


### PR DESCRIPTION
It is now officially announced:
https://x.com/Jeehut/status/1800327507662786913

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.
