### PR TITLE
Add Epoch promo offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Are you running a sale during WWDC? Open a pull request with more information!
 - [50%-off **Stealthly** with WWDC25 coupon code - Automated Privacy for macOS Screen Sharing](https://stealthly.app) Ends June 13.
 - [Save 20% on **Swifty Compiler (Swift IDE for iOS)** lifetime access](https://apps.apple.com/app/id1544749600) from [Hassan Taleb](https://x.com/hassantaleb90)
 - [50% off Lifetime License on **SimpleFill** on the Mac App Store from June 9th-14th](https://apps.apple.com/app/id6743927264) from [Ram Patra](https://x.com/rampatra_)
+- [100% off Epoch - TV & Movie tracker, lifetime premium (iOS)](https://apps.apple.com/app/id6502776057) from [Pavel Kroupa](https://x.com/withtabonx)
 
 <p>&nbsp;</p>
 


### PR DESCRIPTION
App name - TV & Movie Tracker - Epoch
Original price - $6.99
Offer price - $0.00
Link - https://apps.apple.com/app/id6502776057

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.

## Optional for links to paid products
* [x] The link regards a discounted paid product. I put it in the Offers category.
* [x] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
