### PR TITLE
Add LaunchBuddy WWDC discount

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Are you running a sale during WWDC? Open a pull request with more information!
 - [50% off LifeList premium lifetime - Make bucketlists together](https://apps.apple.com/app/lifelists-bucketlist/id6745145322) - till the end of June - from [Maarten Borsje](https://x.com/maartenborsje)
 - [37.5% off BleepList premium yearly - The easiest shopping list for your entire family](https://apps.apple.com/app/id6467556653) - till 15th of June - from [Maarten Borsje](https://x.com/maartenborsje) 
 - [25% off with code WWDC25 on iCloudShipper. The guide to icloud sharing](https://maartenborsje.gumroad.com/l/iCloudShipper/WWDC25) - from [Maarten Borsje](https://x.com/maartenborsje) & [Tim Hilker](https://x.com/timgk1)
+- [Over 50% off **LaunchBuddy Pro** - Project management made for indie developers; Releases, Tasks, Checklists, Feedback & more](https://launchbuddy.app/wwdc25) - till 15th of June - from [Flo writes Code](https://x.com/FloWritesCode)
 <p>&nbsp;</p>
 
 ### Chat groups


### PR DESCRIPTION
Adds app discount bullet for LaunchBuddy, including duration and link to X

## Checklist
* [X] The link is freely available for everyone to read.
* [X] The link hasn't already been submitted.
* [X] I placed the link at the bottom of its category.
* [X] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [X] The link isn't about rumors.
* [X] The linked material is suitable for a general audience.

## Optional for links to paid products
* [X] The link regards a discounted paid product. I put it in the Offers category.
* [X] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
