### PR TITLE
Add new community projects section for WWDC Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ You're welcome to add your own in a pull request – please ensure your country 
 - 🇬🇧 June 9th, 5:30pm - 8:30pm BST: [NSLondon WWDC25 keynote viewing party at Ford](https://www.meetup.com/nslondon/events/307821543/), London, United Kingdom
 - 🇺🇸 June 9th, 11:00am - 2pm CDT: [STL Swift WWDC Watch Event](https://www.eventbrite.com/e/stl-swift-wwdc-2025-watch-event-tickets-1363806113799), Saint Louis, Missouri,
 
+### Community Learning Resources
+
+Collaborative resources created by and for the developer community:
+
+- [WWDC Notes](https://wwdcnotes.com/documentation/wwdcnotes/): Session notes written by 60+ developers – and you? [Join our Slack](https://join.slack.com/t/wwdc-notes/shared_invite/zt-1wbsoo705-bydJ430uZSRILstG5GxEzg) to help!
+
+<p>&nbsp;</p>
+
 ### Course discounts
 
 Save money with these discounts on Swift learning material:


### PR DESCRIPTION
I couldn't find any other section this fits in. Last year, we had a "Events around the world and online" section, but I feel this is more of a community learning resource and there might be potentially others (in the future), so I chose this name. Feel free to adjust or move around if needed.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.