### PR TITLE
Fix: Correct event times to 12-hour format and standardize

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SUNDAY, June 8th
 - **3:00pm-7:00pm: [WWDC Check-in, refreshments, and games at Infinite Loop](https://developer.apple.com/wwdc25/) (requires WWDC ticket - 🍎)**
 - 6:30pm-11:00pm: [RevenueCat's Pre-WWDC Bashcade](https://lu.ma/94pquugz) (requires a ticket)
 - 7:00pm-9:00pm: [Dr. Funk's Tech House @ WWDC](https://lu.ma/rk6326z7) by The App Association
-- 9:00am-18:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
+- 9:00am-6:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
 
 MONDAY, June 9th
 - **9:00am-4:00pm: [Special Event at Apple Park](https://developer.apple.com/wwdc25/special-event/) (requires WWDC ticket - 🍎)**
@@ -39,14 +39,14 @@ MONDAY, June 9th
 - 4:00pm-6:00pm: [Vision Pro Meetup at CommunityKit](https://lu.ma/jz8wgmls?tk=4LWDfR)
 - 7:00pm-10:00pm: [Students, Swift, St★rs](https://ti.to/ios-conf-sg/students-swift-stars-2025)
 - 7:00pm-10:30pm: 🇫🇷🇨🇦🇱🇺🇧🇪 [The French Dinner](https://lu.ma/9vs7dmot) (requires registration)
-- 9:00am-18:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
+- 9:00am-6:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
 
 TUESDAY, June 10th
 - 7:00am-9:00am: [WWDC Women's Get-Together Breakfast](https://lu.ma/lcaz5v0q) (RSVP Required)
 - **10:00am-6:00pm: [Apple Developer Center Sessions - Morning, Afternoon, Evening](https://developer.apple.com/wwdc24/special-event/) (requires WWDC ticket - 🍎)**
 - 7:00am-5:00pm: [CommunityKit](https://communitykit.social)
 - 8:00am-5:30pm: [One More Thing 2025](https://omt-conf.com/wwdc25)
-- 9:00am-18:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
+- 9:00am-6:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
 (https://iosdevhappyhour.com)
 - 11:00am - 1:00pm: [Core Coffee – WWDC Edition pt. 2 ☕️](https://www.meetup.com/core-coffee-a-catch-up-for-ios-and-macos-developers/events/307593020/?eventOrigin=group_upcoming_events)
 - 2:00pm-4:00pm: [RocketSim Meetup at CommunityKit](https://lu.ma/g4m3q37q) (requires Registration)
@@ -60,7 +60,7 @@ TUESDAY, June 10th
 WEDNESDAY, June 11th
 - 9:00am-5:00pm: [CommunityKit](https://communitykit.social)
 - 8:00am-5:30pm: [One More Thing 2025](https://omt-conf.com/wwdc25)
-- 9:00am-18:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
+- 9:00am-6:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
 - 12:00pm-1:30pm: [Annual WWDC Women's Lunch (unofficial)](https://www.meetup.com/swift-language/events/307194649) (free)
 - 4:00pm-6:00pm: [Vapor@WWDC](https://lu.ma/zihfxdqz?tk=ICYWZJ) (free)
 - 4:30pm-6:00pm: [AiOS Meetup](https://lu.ma/aios-omt) (free)
@@ -69,7 +69,7 @@ WEDNESDAY, June 11th
 
 THURSDAY, June 12th
 - 8:30am-7:00pm: [One More Thing 2025](https://omt-conf.com/wwdc25)
-- 9:00am-18:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
+- 9:00am-6:00pm: [A Vision Pro Spatial Art Experience  — Flatland: Mixed Reality Dreams](https://story.app/wwdc) (free)
 - 11:00am-1:00pm: [Core Coffee X LookUp Anniversary](https://www.meetup.com/core-coffee-a-catch-up-for-ios-and-macos-developers/events/307594098/?eventOrigin=group_upcoming_events)
 - 12:00pm-6:00pm: [Code Crawl @ WWDC](https://lu.ma/lc8o9js7) (free)
 - 4:00pm-6:00pm: [Stanford Spezi WWDC Meetup](http://bit.ly/SpeziWWDC) (free)
@@ -86,13 +86,13 @@ If you’d like to watch Apple’s keynote with other folks, you’re in luck! T
 You're welcome to add your own in a pull request – please ensure your country is alphabetically sorted!
 
 - 🇫🇷 June 9th, 6:30pm - 9:30pm CEST: [CocoaHeads special WWDC chez Voodoo](https://dubdub.community/cocoaheads-special-wwdc-chez-voodoo-esbw5e), Paris, France
-- 🇮🇱 June 9th, 7:00pm - 11pm IDT: [WWDC'25 TLV Watch Party @ monday.com](https://mndy.me/wwdc25), Tel Aviv, Israel
+- 🇮🇱 June 9th, 7:00pm - 11:00pm IDT: [WWDC'25 TLV Watch Party @ monday.com](https://mndy.me/wwdc25), Tel Aviv, Israel
 - 🇮🇳 June 9th, 7:30pm - 12:30am IST: [WWDC'25 Watch Party Ahmedabad](https://lu.ma/kne1yfpm), Ahmedabad, India
 - 🇵🇭 June 9th, 12:00am - 3:00am PHT: [SwiftPH WWDC Keynote Watch Party](https://www.meetup.com/swiftph/events/307600367/?eventOrigin=group_upcoming_events), Manila and Davao, Philippines
-- 🇹🇷 June 9th, 7:00pm - 10pm IST: [WWDC'25 Watch Party @ Komunite Space](https://kommunity.com/nsistanbul/events/wwdc25-seyir-partisi-6c721925), Istanbul, Turkey
+- 🇹🇷 June 9th, 7:00pm - 10:00pm IST: [WWDC'25 Watch Party @ Komunite Space](https://kommunity.com/nsistanbul/events/wwdc25-seyir-partisi-6c721925), Istanbul, Turkey
 - 🇬🇧 June 9th, 5:30pm - 8:00pm BST: [NSManchester WWDC25 Watch Party at Jaguar Land Rover](https://www.meetup.com/nsmanchester/events/306569717), Manchester, UK
 - 🇬🇧 June 9th, 5:30pm - 8:30pm BST: [NSLondon WWDC25 keynote viewing party at Ford](https://www.meetup.com/nslondon/events/307821543/), London, United Kingdom
-- 🇺🇸 June 9th, 11:00am - 2pm CDT: [STL Swift WWDC Watch Event](https://www.eventbrite.com/e/stl-swift-wwdc-2025-watch-event-tickets-1363806113799), Saint Louis, Missouri,
+- 🇺🇸 June 9th, 11:00am - 2:00pm CDT: [STL Swift WWDC Watch Event](https://www.eventbrite.com/e/stl-swift-wwdc-2025-watch-event-tickets-1363806113799), Saint Louis, Missouri,
 
 ### Community Learning Resources
 


### PR DESCRIPTION
This commit addresses an issue where some event times in README.md were incorrectly using a 24-hour format (e.g., "18:00pm"). These have been converted to the proper 12-hour format (e.g., "6:00pm").

Additionally, other time mentions have been standardized for consistency to use the HH:MMam/pm format (e.g., "11pm" changed to "11:00pm").

