### PR TITLE
Added first App Discount, for LookBack+!

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ Save money with these discounts on Swift learning material:
 
 - [Save 50% on Hacking with Swift books and bundles](https://www.hackingwithswift.com/offers)
 
+
+### App discounts
+Save money with these discounts on apps from the community:
+- [Enjoy 26% off on LookBack+, re-imagine NameDropping at WWDC!](https://wwdc.lookback.tech/)
+
 <p>&nbsp;</p>
 
 ### Chat groups


### PR DESCRIPTION
Just submitted the first app discount! For our app, LookBack: https://apps.apple.com/us/app/lookback-contacts-history/id6762175300

## Optional for links to paid products
* [x] The link regards a discounted paid product. I put it in the Offers category.
* [x] This is the only Offers link I have submitted or updated. (Send just one link for multiple offers to avoid overwhelming the list.)
