### PR TITLE
Post WWDC Section: 46 events around the world

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,27 +162,27 @@ Now that the big week week is over, there’s a lot to discuss from what was ann
 #### Apple-hosted events
 Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: The biggest updates from WWDC26,”_ to share tips for your apps and for you to meet developers in your region.
 
-- 🇧🇷 June 23rd, 2:00pm-5:00pm GMT-3: Apple São Paulo, Brazilian Portuguese
-- 🇧🇷 June 25th, 9:00am-12:00pm GMT-3: Apple Developer Academy | PUC-RS, Brazilian Portuguese
+- 🇧🇷 June 23rd, 2:00pm-5:00pm BRT: Apple São Paulo, Brazilian Portuguese
+- 🇧🇷 June 25th, 9:00am-12:00pm BRT: Apple Developer Academy | PUC-RS, Brazilian Portuguese
 - 🇨🇦 July 7th, 2:00pm-5:00pm EDT: Apple Toronto, English
 - 🇨🇦 July 9th, 2:00pm-5:00pm EDT: Apple Montreal, English
 - 🇨🇦 July 21st, 2:00pm-5:00pm PDT: Apple Vancouver, English
 - 🇨🇦 July 23rd, 12:30pm-3:00pm MDT: The Calgary Zoo, English
-- 🇩🇪 June 30th, 9:00am-7:00pm GMT+2: Apple Berlin, English
-- 🇬🇧 June 23rd, 9:00am-7:00pm GMT+1: Workshop: Implement the latest technologies from WWDC26 at Barbican Centre, London, English
-- 🇬🇧 June 24th, 9:00am-6:00pm GMT+1: Apple London (1 Bank Street), English
-- 🇮🇩 July 7th, 2:00pm-6:00pm GMT+7: Apple Developer Academy, Jakarta, English
-- 🇮🇳 June 30th, 9:00am-5:00pm GMT+5:30: Apple Developer Center Bengaluru, English
-- 🇮🇳 July 3rd, 9:00am-1:00pm GMT+5:30: Radisson Blu Plaza, Delhi Airport, English
-- 🇮🇳 July 3rd, 2:00pm-6:00pm GMT+5:30: Radisson Blu Plaza, Delhi Airport, English
-- 🇮🇳 July 9th, 9:00am-1:00pm GMT+5:30: Apple Developer Center Bengaluru, English
-- 🇯🇵 June 30th, 5:30pm-8:30pm GMT+9: Apple Japan, Japanese
-- 🇯🇵 July 2nd, 5:30pm-8:00pm GMT+9: WeWork Midosuji Frontier, Osaka, Japanese
-- 🇰🇷 June 26th, 12:00pm-6:00pm GMT+9: Seoul, Korean
-- 🇲🇾 July 9th, 2:00pm-6:00pm GMT+8: Hyatt Regency Kuala Lumpur Midtown, Kuala Lumpur, English
+- 🇩🇪 June 30th, 9:00am-7:00pm CEST: Apple Berlin, English
+- 🇬🇧 June 23rd, 9:00am-7:00pm BST: Workshop: Implement the latest technologies from WWDC26 at Barbican Centre, London, English
+- 🇬🇧 June 24th, 9:00am-6:00pm BST: Apple London (1 Bank Street), English
+- 🇮🇩 July 7th, 2:00pm-6:00pm WIB: Apple Developer Academy, Jakarta, English
+- 🇮🇳 June 30th, 9:00am-5:00pm IST: Apple Developer Center Bengaluru, English
+- 🇮🇳 July 3rd, 9:00am-1:00pm IST: Radisson Blu Plaza, Delhi Airport, English
+- 🇮🇳 July 3rd, 2:00pm-6:00pm IST: Radisson Blu Plaza, Delhi Airport, English
+- 🇮🇳 July 9th, 9:00am-1:00pm IST: Apple Developer Center Bengaluru, English
+- 🇯🇵 June 30th, 5:30pm-8:30pm JST: Apple Japan, Japanese
+- 🇯🇵 July 2nd, 5:30pm-8:00pm JST: WeWork Midosuji Frontier, Osaka, Japanese
+- 🇰🇷 June 26th, 12:00pm-6:00pm KST: Seoul, Korean
+- 🇲🇾 July 9th, 2:00pm-6:00pm MYT: Hyatt Regency Kuala Lumpur Midtown, Kuala Lumpur, English
 - 🇲🇽 July 14th, 2:00pm-5:00pm CDT: Apple Mexico City, Spanish
 - 🇲🇽 July 16th, 2:00pm-5:00pm CST: Tec de Monterrey University, Spanish
-- 🇸🇬 June 23rd, 2:00pm-6:00pm GMT+8: Apple Developer Center Singapore, English
+- 🇸🇬 June 23rd, 2:00pm-6:00pm SGT: Apple Developer Center Singapore, English
 - 🇺🇸 July 1st, 2:00pm-5:00pm EDT: Apple Miami, English
 - 🇺🇸 July 14th, 10:00am-12:00pm EDT: New York City, English
 - 🇺🇸 July 23rd, 10:00am-4:00pm PDT: Apple Developer Center Cupertino, English

--- a/README.md
+++ b/README.md
@@ -161,6 +161,38 @@ Now that the big week week is over, there’s a lot to discuss from what was ann
 
 #### Apple-hosted events
 
+- 🇧🇷 June 23rd, 2:00pm-5:00pm GMT-3: Apple São Paulo, Brazilian Portuguese
+- 🇸🇬 June 23rd, 2:00pm-6:00pm GMT+8: Apple Developer Center Singapore, English
+- 🇬🇧 June 23rd, 9:00am-7:00pm GMT+1: Workshop: Implement the latest technologies from WWDC26 at Barbican Centre, London, English
+- 🇬🇧 June 24th, 9:00am-6:00pm GMT+1: Apple London (1 Bank Street), English
+- 🇧🇷 June 25th, 9:00am-12:00pm GMT-3: Apple Developer Academy | PUC-RS, Brazilian Portuguese
+- 🇰🇷 June 26th, 12:00pm-6:00pm GMT+9: Seoul, Korean
+- 🇮🇳 June 30th, 9:00am-5:00pm GMT+5:30: Apple Developer Center Bengaluru, English
+- 🇩🇪 June 30th, 9:00am-7:00pm GMT+2: Apple Berlin, English
+- 🇯🇵 June 30th, 5:30pm-8:30pm GMT+9: Apple Japan, Japanese
+- 🇺🇸 July 1st, 2:00pm-5:00pm EDT: Apple Miami, English
+- 🇯🇵 July 2nd, 5:30pm-8:00pm GMT+9: WeWork Midosuji Frontier, Osaka, Japanese
+- 🇮🇳 July 3rd, 9:00am-1:00pm GMT+5:30: Radisson Blu Plaza, Delhi Airport, English
+- 🇮🇳 July 3rd, 2:00pm-6:00pm GMT+5:30: Radisson Blu Plaza, Delhi Airport, English
+- 🇮🇩 July 7th, 2:00pm-6:00pm GMT+7: Apple Developer Academy, Jakarta, English
+- 🇨🇦 July 7th, 2:00pm-5:00pm EDT: Apple Toronto, English
+- 🇮🇳 July 9th, 9:00am-1:00pm GMT+5:30: Apple Developer Center Bengaluru, English
+- 🇨🇦 July 9th, 2:00pm-5:00pm EDT: Apple Montreal, English
+- 🇲🇾 July 9th, 2:00pm-6:00pm GMT+8: Hyatt Regency Kuala Lumpur Midtown, Kuala Lumpur, English
+- 🇲🇽 July 14th, 2:00pm-5:00pm CDT: Apple Mexico City, Spanish
+- 🇺🇸 July 14th, 10:00am-12:00pm EDT: New York City, English
+- 🇲🇽 July 16th, 2:00pm-5:00pm CST: Tec de Monterrey University, Spanish
+- 🇨🇦 July 21st, 2:00pm-5:00pm PDT: Apple Vancouver, English
+- 🇺🇸 July 23rd, 10:00am-4:00pm PDT: Apple Developer Center Cupertino, English
+- 🇨🇦 July 23rd, 12:30pm-3:00pm MDT: The Calgary Zoo, English
+
+Online events
+
+- 🌐 June 25th, 2:00pm-5:00pm GMT+5:30: London, English
+- 🌐 June 30th, 7:00am-2:30pm GMT+5:30: Shanghai, Simplified Chinese
+- 🌐 July 3rd, 9:30am-11:30am GMT+5:30: Seoul, Korean
+- 🌐 July 23rd-24th, 10:30pm-12:30am GMT+5:30: Apple Developer Center Cupertino, English
+
 #### Community-hosted events, by country
 
 ### Course discounts

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ You're welcome to add your own in a pull request – please ensure your country 
 
 <p>&nbsp;</p>
 
-### Post WWDC Events
+## Post WWDC Events
 Now that the big week week is over, there’s a lot to discuss from what was announced. Apple, and the community, are continuing to host events around the world to keep the energy going.
 
-#### Apple-hosted events
+### Apple-hosted events
 Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: The biggest updates from WWDC26,”_ to share tips for your apps and for you to meet developers in your region.
 
 - 🇧🇷 June 23rd, 2:00pm-5:00pm BRT: Apple São Paulo, Brazilian Portuguese
@@ -191,7 +191,7 @@ Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: T
 - 🌐 July 3rd, 1:00pm-3:00pm KST: Seoul, Korean
 - 🌐 July 23rd, 10:00am-11:59pm PDT and July 24th, 12:00am-1:59am PDT: Apple Developer Center Cupertino, English
 
-#### Community-hosted events, by country
+### Community-hosted events, by country
 
 🌐 Online
 - June 20th: [WWDC 2026 Recap and Discussion](https://luma.com/fuk5151s), Online

--- a/README.md
+++ b/README.md
@@ -196,6 +196,35 @@ Online events
 
 #### Community-hosted events, by country
 
+🇦🇺 Australia
+- July 2nd-3rd: [/dev/world on tour](https://ontour.devworld.au/index.php), Sydney, Australia
+
+🇨🇦 Canada
+- July 28th: [Tacow July Meetup](https://luma.com/9olvx72d), Toronto, Canada
+
+🇯🇵 Japan
+- June 19th: [Recap of WWDC26](https://mercari.connpass.com/event/391605/), Tokyo, Japan
+- June 20th: [yidev: Yokohama Apple Developers Meetup](https://yidev4.connpass.com/event/391446/), Yokohama, Japan
+- June 26th: [Swift Lovers Club - WWDC26 Recap](https://love-swift.connpass.com/event/390480/), Shibuya, Japan
+- June 28th: [Swift Kansai - iOS and macOS Developer Meetup (WWDC Edition)](https://www.meetup.com/swift-kansai/events/314573983/), Osaka, Japan
+- July 12th: [WWDC Recap for Swift Students](https://swiftstudents.jp/en/events/wwdc-recap-2026), Roppongi Hills, Japan
+- July 18th: [WWDC26 Recap - Japan-\\(region).swift](https://luma.com/x230s9i1), Multiple Cities, Japan
+
+🇳🇬 Nigeria
+- June 20th: [WWDC 2026 Lagos Hangout](https://luma.com/jrtha1q8), Ikeja, Nigeria
+
+🇸🇬 Singapore
+- June 23rd: [iOS Dev Scout Beyond WWDC 2026](https://luma.com/vfmlqe1i), Singapore
+
+🇰🇷 South Korea
+- June 20th: [After Tech Club: vol 1. WWDC26 Recap](https://ticketa.co/event/qihrrgnk/l/5F8JZoN6?utm_source=da), Seoul, South Korea
+
+🇱🇰 Sri Lanka
+- June 18th: [Swift Sri Lanka Meetup - Beyond WWDC](https://www.meetup.com/swift-sri-lanka/events/314936926/), Colombo, Sri Lanka
+
+🇦🇪 United Arab Emirates
+- June 20th: [WWDC26 Unpacked](https://luma.com/vp473z2r), Dubai, United Arab Emirates
+
 ### Course discounts
 
 Save money with these discounts on Swift learning material:

--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: T
 
 Online events
 
-- 🌐 June 25th, 2:00pm-5:00pm GMT+5:30: London, English
-- 🌐 June 30th, 7:00am-2:30pm GMT+5:30: Shanghai, Simplified Chinese
-- 🌐 July 3rd, 9:30am-11:30am GMT+5:30: Seoul, Korean
-- 🌐 July 23rd-24th, 10:30pm-12:30am GMT+5:30: Apple Developer Center Cupertino, English
+- 🌐 June 25th, 9:30am-12:30pm BST: London, English
+- 🌐 June 30th, 9:30am-5:00pm CST: Shanghai, Simplified Chinese
+- 🌐 July 3rd, 1:00pm-3:00pm KST: Seoul, Korean
+- 🌐 July 23rd, 10:00am-11:59pm PDT and July 24th, 12:00am-1:59am PDT: Apple Developer Center Cupertino, English
 
 #### Community-hosted events, by country
 

--- a/README.md
+++ b/README.md
@@ -159,38 +159,6 @@ You're welcome to add your own in a pull request – please ensure your country 
 ## Post WWDC Events
 Now that the big week week is over, there’s a lot to discuss from what was announced. Apple, and the community, are continuing to host events around the world to keep the energy going.
 
-### Apple-hosted events
-Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: The biggest updates from WWDC26,”_ to share tips for your apps and for you to meet developers in your region.
-
-- 🇧🇷 June 23rd, 2:00pm-5:00pm BRT: Apple São Paulo, Brazilian Portuguese
-- 🇧🇷 June 25th, 9:00am-12:00pm BRT: Apple Developer Academy | PUC-RS, Brazilian Portuguese
-- 🇨🇦 July 7th, 2:00pm-5:00pm EDT: Apple Toronto, English
-- 🇨🇦 July 9th, 2:00pm-5:00pm EDT: Apple Montreal, English
-- 🇨🇦 July 21st, 2:00pm-5:00pm PDT: Apple Vancouver, English
-- 🇨🇦 July 23rd, 12:30pm-3:00pm MDT: The Calgary Zoo, English
-- 🇩🇪 June 30th, 9:00am-7:00pm CEST: Apple Berlin, English
-- 🇬🇧 June 23rd, 9:00am-7:00pm BST: Workshop: Implement the latest technologies from WWDC26 at Barbican Centre, London, English
-- 🇬🇧 June 24th, 9:00am-6:00pm BST: Apple London (1 Bank Street), English
-- 🇮🇩 July 7th, 2:00pm-6:00pm WIB: Apple Developer Academy, Jakarta, English
-- 🇮🇳 June 30th, 9:00am-5:00pm IST: Apple Developer Center Bengaluru, English
-- 🇮🇳 July 3rd, 9:00am-1:00pm IST: Radisson Blu Plaza, Delhi Airport, English
-- 🇮🇳 July 3rd, 2:00pm-6:00pm IST: Radisson Blu Plaza, Delhi Airport, English
-- 🇮🇳 July 9th, 9:00am-1:00pm IST: Apple Developer Center Bengaluru, English
-- 🇯🇵 June 30th, 5:30pm-8:30pm JST: Apple Japan, Japanese
-- 🇯🇵 July 2nd, 5:30pm-8:00pm JST: WeWork Midosuji Frontier, Osaka, Japanese
-- 🇰🇷 June 26th, 12:00pm-6:00pm KST: Seoul, Korean
-- 🇲🇾 July 9th, 2:00pm-6:00pm MYT: Hyatt Regency Kuala Lumpur Midtown, Kuala Lumpur, English
-- 🇲🇽 July 14th, 2:00pm-5:00pm CDT: Apple Mexico City, Spanish
-- 🇲🇽 July 16th, 2:00pm-5:00pm CST: Tec de Monterrey University, Spanish
-- 🇸🇬 June 23rd, 2:00pm-6:00pm SGT: Apple Developer Center Singapore, English
-- 🇺🇸 July 1st, 2:00pm-5:00pm EDT: Apple Miami, English
-- 🇺🇸 July 14th, 10:00am-12:00pm EDT: New York City, English
-- 🇺🇸 July 23rd, 10:00am-4:00pm PDT: Apple Developer Center Cupertino, English
-- 🌐 June 25th, 9:30am-12:30pm BST: London, English
-- 🌐 June 30th, 9:30am-5:00pm CST: Shanghai, Simplified Chinese
-- 🌐 July 3rd, 1:00pm-3:00pm KST: Seoul, Korean
-- 🌐 July 23rd, 10:00am-11:59pm PDT and July 24th, 12:00am-1:59am PDT: Apple Developer Center Cupertino, English
-
 ### Community-hosted events, by country
 
 🌐 Online
@@ -232,6 +200,38 @@ Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: T
 🇺🇸 United States
 - June 16th: [CocoaHeads x Swift Language User Group (SLUG) | June 16th | San Francisco | at Sentry HQ](https://luma.com/pdrj5h10), San Francisco, CA, United States
 - June 18th: [Siri AI Automators meetup (Portland)](https://luma.com/z6gbu7tb), Portland, OR, United States
+
+### Apple-hosted events
+Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: The biggest updates from WWDC26,”_ to share tips for your apps and for you to meet developers in your region.
+
+- 🇧🇷 June 23rd, 2:00pm-5:00pm BRT: Apple São Paulo, Brazilian Portuguese
+- 🇧🇷 June 25th, 9:00am-12:00pm BRT: Apple Developer Academy | PUC-RS, Brazilian Portuguese
+- 🇨🇦 July 7th, 2:00pm-5:00pm EDT: Apple Toronto, English
+- 🇨🇦 July 9th, 2:00pm-5:00pm EDT: Apple Montreal, English
+- 🇨🇦 July 21st, 2:00pm-5:00pm PDT: Apple Vancouver, English
+- 🇨🇦 July 23rd, 12:30pm-3:00pm MDT: The Calgary Zoo, English
+- 🇩🇪 June 30th, 9:00am-7:00pm CEST: Apple Berlin, English
+- 🇬🇧 June 23rd, 9:00am-7:00pm BST: Workshop: Implement the latest technologies from WWDC26 at Barbican Centre, London, English
+- 🇬🇧 June 24th, 9:00am-6:00pm BST: Apple London (1 Bank Street), English
+- 🇮🇩 July 7th, 2:00pm-6:00pm WIB: Apple Developer Academy, Jakarta, English
+- 🇮🇳 June 30th, 9:00am-5:00pm IST: Apple Developer Center Bengaluru, English
+- 🇮🇳 July 3rd, 9:00am-1:00pm IST: Radisson Blu Plaza, Delhi Airport, English
+- 🇮🇳 July 3rd, 2:00pm-6:00pm IST: Radisson Blu Plaza, Delhi Airport, English
+- 🇮🇳 July 9th, 9:00am-1:00pm IST: Apple Developer Center Bengaluru, English
+- 🇯🇵 June 30th, 5:30pm-8:30pm JST: Apple Japan, Japanese
+- 🇯🇵 July 2nd, 5:30pm-8:00pm JST: WeWork Midosuji Frontier, Osaka, Japanese
+- 🇰🇷 June 26th, 12:00pm-6:00pm KST: Seoul, Korean
+- 🇲🇾 July 9th, 2:00pm-6:00pm MYT: Hyatt Regency Kuala Lumpur Midtown, Kuala Lumpur, English
+- 🇲🇽 July 14th, 2:00pm-5:00pm CDT: Apple Mexico City, Spanish
+- 🇲🇽 July 16th, 2:00pm-5:00pm CST: Tec de Monterrey University, Spanish
+- 🇸🇬 June 23rd, 2:00pm-6:00pm SGT: Apple Developer Center Singapore, English
+- 🇺🇸 July 1st, 2:00pm-5:00pm EDT: Apple Miami, English
+- 🇺🇸 July 14th, 10:00am-12:00pm EDT: New York City, English
+- 🇺🇸 July 23rd, 10:00am-4:00pm PDT: Apple Developer Center Cupertino, English
+- 🌐 June 25th, 9:30am-12:30pm BST: London, English
+- 🌐 June 30th, 9:30am-5:00pm CST: Shanghai, Simplified Chinese
+- 🌐 July 3rd, 1:00pm-3:00pm KST: Seoul, Korean
+- 🌐 July 23rd, 10:00am-11:59pm PDT and July 24th, 12:00am-1:59am PDT: Apple Developer Center Cupertino, English
 
 ### Course discounts
 

--- a/README.md
+++ b/README.md
@@ -157,9 +157,7 @@ You're welcome to add your own in a pull request – please ensure your country 
 <p>&nbsp;</p>
 
 ## Post WWDC Events
-Now that the big week week is over, there’s a lot to discuss from what was announced. Apple, and the community, are continuing to host events around the world to keep the energy going.
-
-### Community-hosted events, by country
+Now that the big week is over, there’s a lot to discuss from what was announced. The community is continuing to host events around the world to keep the energy going.
 
 🌐 Online
 - June 20th: [WWDC 2026 Recap and Discussion](https://luma.com/fuk5151s), Online
@@ -200,38 +198,6 @@ Now that the big week week is over, there’s a lot to discuss from what was ann
 🇺🇸 United States
 - June 16th: [CocoaHeads x Swift Language User Group (SLUG) | June 16th | San Francisco | at Sentry HQ](https://luma.com/pdrj5h10), San Francisco, CA, United States
 - June 18th: [Siri AI Automators meetup (Portland)](https://luma.com/z6gbu7tb), Portland, OR, United States
-
-### Apple-hosted events
-Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: The biggest updates from WWDC26,”_ to share tips for your apps and for you to meet developers in your region.
-
-- 🇧🇷 June 23rd, 2:00pm-5:00pm BRT: Apple São Paulo, Brazilian Portuguese
-- 🇧🇷 June 25th, 9:00am-12:00pm BRT: Apple Developer Academy | PUC-RS, Brazilian Portuguese
-- 🇨🇦 July 7th, 2:00pm-5:00pm EDT: Apple Toronto, English
-- 🇨🇦 July 9th, 2:00pm-5:00pm EDT: Apple Montreal, English
-- 🇨🇦 July 21st, 2:00pm-5:00pm PDT: Apple Vancouver, English
-- 🇨🇦 July 23rd, 12:30pm-3:00pm MDT: The Calgary Zoo, English
-- 🇩🇪 June 30th, 9:00am-7:00pm CEST: Apple Berlin, English
-- 🇬🇧 June 23rd, 9:00am-7:00pm BST: Workshop: Implement the latest technologies from WWDC26 at Barbican Centre, London, English
-- 🇬🇧 June 24th, 9:00am-6:00pm BST: Apple London (1 Bank Street), English
-- 🇮🇩 July 7th, 2:00pm-6:00pm WIB: Apple Developer Academy, Jakarta, English
-- 🇮🇳 June 30th, 9:00am-5:00pm IST: Apple Developer Center Bengaluru, English
-- 🇮🇳 July 3rd, 9:00am-1:00pm IST: Radisson Blu Plaza, Delhi Airport, English
-- 🇮🇳 July 3rd, 2:00pm-6:00pm IST: Radisson Blu Plaza, Delhi Airport, English
-- 🇮🇳 July 9th, 9:00am-1:00pm IST: Apple Developer Center Bengaluru, English
-- 🇯🇵 June 30th, 5:30pm-8:30pm JST: Apple Japan, Japanese
-- 🇯🇵 July 2nd, 5:30pm-8:00pm JST: WeWork Midosuji Frontier, Osaka, Japanese
-- 🇰🇷 June 26th, 12:00pm-6:00pm KST: Seoul, Korean
-- 🇲🇾 July 9th, 2:00pm-6:00pm MYT: Hyatt Regency Kuala Lumpur Midtown, Kuala Lumpur, English
-- 🇲🇽 July 14th, 2:00pm-5:00pm CDT: Apple Mexico City, Spanish
-- 🇲🇽 July 16th, 2:00pm-5:00pm CST: Tec de Monterrey University, Spanish
-- 🇸🇬 June 23rd, 2:00pm-6:00pm SGT: Apple Developer Center Singapore, English
-- 🇺🇸 July 1st, 2:00pm-5:00pm EDT: Apple Miami, English
-- 🇺🇸 July 14th, 10:00am-12:00pm EDT: New York City, English
-- 🇺🇸 July 23rd, 10:00am-4:00pm PDT: Apple Developer Center Cupertino, English
-- 🌐 June 25th, 9:30am-12:30pm BST: London, English
-- 🌐 June 30th, 9:30am-5:00pm CST: Shanghai, Simplified Chinese
-- 🌐 July 3rd, 1:00pm-3:00pm KST: Seoul, Korean
-- 🌐 July 23rd, 10:00am-11:59pm PDT and July 24th, 12:00am-1:59am PDT: Apple Developer Center Cupertino, English
 
 ### Course discounts
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Online events
 - July 2nd-3rd: [/dev/world on tour](https://ontour.devworld.au/index.php), Sydney, Australia
 
 🇨🇦 Canada
+- June 14th: [Core Coffee – Post-WWDC In-Person Edition ☕️](https://luma.com/j24hiaxs), Vancouver, Canada
 - July 28th: [Tacow July Meetup](https://luma.com/9olvx72d), Toronto, Canada
 
 🇮🇳 India

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ Online events
 🇦🇪 United Arab Emirates
 - June 20th: [WWDC26 Unpacked](https://luma.com/vp473z2r), Dubai, United Arab Emirates
 
+🇺🇸 United States
+- June 18th: [Siri AI Automators meetup (Portland)](https://luma.com/z6gbu7tb), Portland, OR, United States
+
 ### Course discounts
 
 Save money with these discounts on Swift learning material:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ You're welcome to add your own in a pull request – please ensure your country 
 
 <p>&nbsp;</p>
 
+### Post WWDC Events
+Now that the big week week is over, there’s a lot to discuss from what was announced. Apple, and the community, are continuing to host events around the world to keep the energy going.
+
+#### Apple-hosted events
+
+#### Community-hosted events, by country
+
 ### Course discounts
 
 Save money with these discounts on Swift learning material:

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ Online events
 
 #### Community-hosted events, by country
 
+🌐 Online
+- June 20th: [WWDC 2026 Recap and Discussion](https://luma.com/fuk5151s), Online
+
 🇦🇺 Australia
 - July 2nd-3rd: [/dev/world on tour](https://ontour.devworld.au/index.php), Sydney, Australia
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Online events
 🇨🇦 Canada
 - July 28th: [Tacow July Meetup](https://luma.com/9olvx72d), Toronto, Canada
 
+🇮🇳 India
+- June 20th: [What’s new at Google I/O and Apple WWDC](https://luma.com/eoy5m8v0), Mumbai, India
+
 🇯🇵 Japan
 - June 19th: [Recap of WWDC26](https://mercari.connpass.com/event/391605/), Tokyo, Japan
 - June 20th: [yidev: Yokohama Apple Developers Meetup](https://yidev4.connpass.com/event/391446/), Yokohama, Japan

--- a/README.md
+++ b/README.md
@@ -163,32 +163,29 @@ Now that the big week week is over, there’s a lot to discuss from what was ann
 Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: The biggest updates from WWDC26,”_ to share tips for your apps and for you to meet developers in your region.
 
 - 🇧🇷 June 23rd, 2:00pm-5:00pm GMT-3: Apple São Paulo, Brazilian Portuguese
-- 🇸🇬 June 23rd, 2:00pm-6:00pm GMT+8: Apple Developer Center Singapore, English
+- 🇧🇷 June 25th, 9:00am-12:00pm GMT-3: Apple Developer Academy | PUC-RS, Brazilian Portuguese
+- 🇨🇦 July 7th, 2:00pm-5:00pm EDT: Apple Toronto, English
+- 🇨🇦 July 9th, 2:00pm-5:00pm EDT: Apple Montreal, English
+- 🇨🇦 July 21st, 2:00pm-5:00pm PDT: Apple Vancouver, English
+- 🇨🇦 July 23rd, 12:30pm-3:00pm MDT: The Calgary Zoo, English
+- 🇩🇪 June 30th, 9:00am-7:00pm GMT+2: Apple Berlin, English
 - 🇬🇧 June 23rd, 9:00am-7:00pm GMT+1: Workshop: Implement the latest technologies from WWDC26 at Barbican Centre, London, English
 - 🇬🇧 June 24th, 9:00am-6:00pm GMT+1: Apple London (1 Bank Street), English
-- 🇧🇷 June 25th, 9:00am-12:00pm GMT-3: Apple Developer Academy | PUC-RS, Brazilian Portuguese
-- 🇰🇷 June 26th, 12:00pm-6:00pm GMT+9: Seoul, Korean
+- 🇮🇩 July 7th, 2:00pm-6:00pm GMT+7: Apple Developer Academy, Jakarta, English
 - 🇮🇳 June 30th, 9:00am-5:00pm GMT+5:30: Apple Developer Center Bengaluru, English
-- 🇩🇪 June 30th, 9:00am-7:00pm GMT+2: Apple Berlin, English
-- 🇯🇵 June 30th, 5:30pm-8:30pm GMT+9: Apple Japan, Japanese
-- 🇺🇸 July 1st, 2:00pm-5:00pm EDT: Apple Miami, English
-- 🇯🇵 July 2nd, 5:30pm-8:00pm GMT+9: WeWork Midosuji Frontier, Osaka, Japanese
 - 🇮🇳 July 3rd, 9:00am-1:00pm GMT+5:30: Radisson Blu Plaza, Delhi Airport, English
 - 🇮🇳 July 3rd, 2:00pm-6:00pm GMT+5:30: Radisson Blu Plaza, Delhi Airport, English
-- 🇮🇩 July 7th, 2:00pm-6:00pm GMT+7: Apple Developer Academy, Jakarta, English
-- 🇨🇦 July 7th, 2:00pm-5:00pm EDT: Apple Toronto, English
 - 🇮🇳 July 9th, 9:00am-1:00pm GMT+5:30: Apple Developer Center Bengaluru, English
-- 🇨🇦 July 9th, 2:00pm-5:00pm EDT: Apple Montreal, English
+- 🇯🇵 June 30th, 5:30pm-8:30pm GMT+9: Apple Japan, Japanese
+- 🇯🇵 July 2nd, 5:30pm-8:00pm GMT+9: WeWork Midosuji Frontier, Osaka, Japanese
+- 🇰🇷 June 26th, 12:00pm-6:00pm GMT+9: Seoul, Korean
 - 🇲🇾 July 9th, 2:00pm-6:00pm GMT+8: Hyatt Regency Kuala Lumpur Midtown, Kuala Lumpur, English
 - 🇲🇽 July 14th, 2:00pm-5:00pm CDT: Apple Mexico City, Spanish
-- 🇺🇸 July 14th, 10:00am-12:00pm EDT: New York City, English
 - 🇲🇽 July 16th, 2:00pm-5:00pm CST: Tec de Monterrey University, Spanish
-- 🇨🇦 July 21st, 2:00pm-5:00pm PDT: Apple Vancouver, English
+- 🇸🇬 June 23rd, 2:00pm-6:00pm GMT+8: Apple Developer Center Singapore, English
+- 🇺🇸 July 1st, 2:00pm-5:00pm EDT: Apple Miami, English
+- 🇺🇸 July 14th, 10:00am-12:00pm EDT: New York City, English
 - 🇺🇸 July 23rd, 10:00am-4:00pm PDT: Apple Developer Center Cupertino, English
-- 🇨🇦 July 23rd, 12:30pm-3:00pm MDT: The Calgary Zoo, English
-
-Online events
-
 - 🌐 June 25th, 9:30am-12:30pm BST: London, English
 - 🌐 June 30th, 9:30am-5:00pm CST: Shanghai, Simplified Chinese
 - 🌐 July 3rd, 1:00pm-3:00pm KST: Seoul, Korean

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Online events
 - June 20th: [WWDC26 Unpacked](https://luma.com/vp473z2r), Dubai, United Arab Emirates
 
 🇺🇸 United States
+- June 16th: [CocoaHeads x Swift Language User Group (SLUG) | June 16th | San Francisco | at Sentry HQ](https://luma.com/pdrj5h10), San Francisco, CA, United States
 - June 18th: [Siri AI Automators meetup (Portland)](https://luma.com/z6gbu7tb), Portland, OR, United States
 
 ### Course discounts

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ You're welcome to add your own in a pull request – please ensure your country 
 Now that the big week week is over, there’s a lot to discuss from what was announced. Apple, and the community, are continuing to host events around the world to keep the energy going.
 
 #### Apple-hosted events
+Apple evangelists host annual WWDC recap sessions, _“Discover what’s next: The biggest updates from WWDC26,”_ to share tips for your apps and for you to meet developers in your region.
 
 - 🇧🇷 June 23rd, 2:00pm-5:00pm GMT-3: Apple São Paulo, Brazilian Portuguese
 - 🇸🇬 June 23rd, 2:00pm-6:00pm GMT+8: Apple Developer Center Singapore, English


### PR DESCRIPTION
This PR introduces a post-WWDC section of events, as earlier proposed via email. Marking this as a draft, since there is likely room for improvement in terms of how this is presented.

I have included events found on Apple's Community page, as well as those I came across while scanning Twitter for events.

I've added a new section that follows the watch parties for post-WWDC events.

Considerations, and possible improvements:
- Currently, the offers and discounts are buried under all these events. Do you think they should be moved up?
- To be fair, even the post-wwdc section is quite buried itself. Perhaps the best solution to all of this is to add a picker on the home page to choose what section to view? We give the option to choose between “WWDC In Person Events,” “Watch Parties”, “Post-WWDC Events” and “Chat Groups”. Each of these can link to different .md files in the same repo. I suppose this also solves the challenge @twostraws mentioned about discount codes getting ignored. Happy to draft a new PR to see what that might look like.
