### PR TITLE
Add Step Into Vision Recap + Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You're welcome to add your own in a pull request – please ensure your country 
 Now that the big week is over, there’s a lot to discuss from what was announced. The community is continuing to host events around the world to keep the energy going.
 
 🌐 Online
-- June 20th: [WWDC 2026 Recap and Discussion](https://luma.com/fuk5151s), Online
+- June 20th: [WWDC 2026 Recap and Discussion](https://luma.com/fuk5151s)
 
 🇦🇺 Australia
 - July 2nd-3rd: [/dev/world on tour](https://ontour.devworld.au/index.php), Sydney, Australia

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Now that the big week is over, there’s a lot to discuss from what was announce
 
 🌐 Online
 - June 20th: [WWDC 2026 Recap and Discussion](https://luma.com/fuk5151s)
+- June 27th: [Community Event - Recap WWDC 26 with Step Into Vision](https://stepinto.vision/event/community-event-recap-wwdc-26-with-step-into-vision/)
 
 🇦🇺 Australia
 - July 2nd-3rd: [/dev/world on tour](https://ontour.devworld.au/index.php), Sydney, Australia


### PR DESCRIPTION
Added Step Into Vision WWDC26 Recap, and removed redundant "Online" label which was a leftover from prior experimentation with the format.

## Checklist
* [x] The link is freely available for everyone to read.
* [x] The link hasn't already been submitted.
* [x] I placed the link at the bottom of its category.
* [x] The link is in the correct format: `[Post name](link to post) from [Author name](optional author link)`. For example, `[My WWDC 2020 Wishlist](https://beckyhansmeyer.com/2020/05/13/my-wwdc-2020-wishlist/) from Becky Hansmeyer`.
* [x] The link isn't about rumors.
* [x] The linked material is suitable for a general audience.